### PR TITLE
Added classes Connect.Call and StoredProcedureOutcome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ target/
 .idea/
 *.iml
 .DS_Store
-/bin/
+bin/
 .classpath
 .project
 .settings/
-

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ target/
 .idea/
 *.iml
 .DS_Store
+/bin/
+.classpath
+.project
+.settings/
+

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
             <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,7 @@
                                 </goals>
                                 <configuration>
                                     <repoToken>${coveralls.token.jdbc}</repoToken>
+                                    <timestampFormat>yyyy-MM-dd'T'HH:mm:ss</timestampFormat>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/main/java/com/jcabi/jdbc/Connect.java
+++ b/src/main/java/com/jcabi/jdbc/Connect.java
@@ -56,7 +56,6 @@ interface Connect {
     /**
      * Connect which opens a <b>CallableStatement</b>, which
      * is used for calling stored procedures.
-     *
      */
     final class Call implements Connect {
 

--- a/src/main/java/com/jcabi/jdbc/Connect.java
+++ b/src/main/java/com/jcabi/jdbc/Connect.java
@@ -54,14 +54,44 @@ interface Connect {
     PreparedStatement open(Connection conn) throws SQLException;
 
     /**
+     * Connect which opens a <b>CallableStatement</b>, which
+     * is used for calling stored procedures.
+     *
+     */
+    final class Call implements Connect {
+
+        /**
+         * SQL function call.
+         */
+        private final String sql;
+
+        /**
+         * Ctor.
+         * @param query Query
+         */
+        public Call(final String query) {
+            this.sql = query;
+        }
+
+        @Override
+        public PreparedStatement open(final Connection conn)
+            throws SQLException {
+            return conn.prepareCall(this.sql);
+        }
+
+    }
+
+    /**
      * Plain, without keys.
      */
     @Immutable
     final class Plain implements Connect {
+
         /**
          * SQL query.
          */
         private final transient String sql;
+
         /**
          * Ctor.
          * @param query Query
@@ -69,6 +99,7 @@ interface Connect {
         public Plain(final String query) {
             this.sql = query;
         }
+
         @Override
         public PreparedStatement open(final Connection conn)
             throws SQLException {
@@ -81,10 +112,12 @@ interface Connect {
      */
     @Immutable
     final class WithKeys implements Connect {
+
         /**
          * SQL query.
          */
         private final transient String sql;
+
         /**
          * Ctor.
          * @param query Query
@@ -92,6 +125,7 @@ interface Connect {
         public WithKeys(final String query) {
             this.sql = query;
         }
+
         @Override
         public PreparedStatement open(final Connection conn)
             throws SQLException {
@@ -100,6 +134,7 @@ interface Connect {
                 Statement.RETURN_GENERATED_KEYS
             );
         }
+
     }
 
 }

--- a/src/main/java/com/jcabi/jdbc/JdbcSession.java
+++ b/src/main/java/com/jcabi/jdbc/JdbcSession.java
@@ -315,7 +315,10 @@ public final class JdbcSession {
     /**
      * Call an SQL stored procedure.
      *
-     * <p>JDBC connection is opened and, optionally, closed by this method.
+     * <p>JDBC connection is opened and, optionally, commited by this
+     * method, depending on the <b>autocommit</b> class attribute:
+     * if it's value is true, the connection will be commited after
+     * this call.
      *
      * @param <T> Type of result expected
      * @param outcome Outcome of the operation

--- a/src/main/java/com/jcabi/jdbc/JdbcSession.java
+++ b/src/main/java/com/jcabi/jdbc/JdbcSession.java
@@ -107,6 +107,8 @@ import lombok.ToString;
  * @version $Id$
  * @since 0.1.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #51:1h Refactor this class to avoid too much coupling.
+ *  For instance, CRUD operations could be performed by another class.
  */
 @ToString
 @EqualsAndHashCode(of = { "source", "connection", "args", "auto", "query" })
@@ -316,15 +318,13 @@ public final class JdbcSession {
      *
      * @param <T> Type of result expected
      * @param outcome Outcome of the operation
-     * @return This object
+     * @return Result of type T
      * @throws SQLException If fails
      */
     public <T> T call(final Outcome<T> outcome)
         throws SQLException {
         return this.run(
-            outcome,
-            new Connect.Call(this.query),
-            Request.EXECUTE_UPDATE
+            outcome, new Connect.Call(this.query), Request.EXECUTE_UPDATE
         );
     }
 

--- a/src/main/java/com/jcabi/jdbc/JdbcSession.java
+++ b/src/main/java/com/jcabi/jdbc/JdbcSession.java
@@ -106,6 +106,7 @@ import lombok.ToString;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.1.8
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @ToString
 @EqualsAndHashCode(of = { "source", "connection", "args", "auto", "query" })
@@ -304,6 +305,25 @@ public final class JdbcSession {
         return this.run(
             outcome,
             new Connect.WithKeys(this.query),
+            Request.EXECUTE_UPDATE
+        );
+    }
+
+    /**
+     * Call an SQL stored procedure.
+     *
+     * <p>JDBC connection is opened and, optionally, closed by this method.
+     *
+     * @param <T> Type of result expected
+     * @param outcome Outcome of the operation
+     * @return This object
+     * @throws SQLException If fails
+     */
+    public <T> T call(final Outcome<T> outcome)
+        throws SQLException {
+        return this.run(
+            outcome,
+            new Connect.Call(this.query),
             Request.EXECUTE_UPDATE
         );
     }

--- a/src/main/java/com/jcabi/jdbc/JdbcSession.java
+++ b/src/main/java/com/jcabi/jdbc/JdbcSession.java
@@ -107,8 +107,9 @@ import lombok.ToString;
  * @version $Id$
  * @since 0.1.8
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #51:1h Refactor this class to avoid too much coupling.
+ * @todo #51:30min Refactor this class to avoid too much coupling.
  *  For instance, CRUD operations could be performed by another class.
+ *  Don't forget to remove the suppressions that become obsolete afterwards.
  */
 @ToString
 @EqualsAndHashCode(of = { "source", "connection", "args", "auto", "query" })

--- a/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
@@ -46,7 +46,7 @@ import lombok.ToString;
  */
 @Immutable
 @ToString
-@EqualsAndHashCode(of = "indexes")
+@EqualsAndHashCode
 public final class StoredProcedureOutcome<T> implements Outcome<T> {
 
     /**

--- a/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
@@ -91,10 +91,6 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
         }
     }
 
-    /**
-     * Handles the OUT parameter(s) of a stored procedure call and returns
-     * them as <b>Object[]</b>. Therefore, T has to be <b>Object[]</b>.
-     */
     @Override
     @SuppressWarnings("unchecked")
     public T handle(

--- a/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.jdbc;
+
+import com.jcabi.aspects.Immutable;
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Outcome of a stored procedure with OUT parameters.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.7
+ * @param <T> Type of items
+ */
+@Immutable
+@ToString
+@EqualsAndHashCode(of = { "outpidx" })
+public final class StoredProcedureOutcome<T> implements Outcome<T> {
+
+    /**
+     * Indexes of the OUT params.
+     */
+    @Immutable.Array
+    private final transient int[] outpidx;
+
+    /**
+     * Ctor.
+     * @param nrop Number of OUT params. Has to be > 0.
+     *  If this ctor is used, it is assumed that the OUT parameters
+     *  are from index 1 to including nrop.
+     */
+    public StoredProcedureOutcome(final int nrop) {
+        if (nrop <= 0) {
+            throw new IllegalArgumentException(
+                "Nr of out params has to be a positive int!"
+            );
+        }
+        this.outpidx = new int[nrop];
+        for (int idx = 0; idx < nrop; ++idx) {
+            this.outpidx[idx] = idx + 1;
+        }
+    }
+
+    /**
+     * Ctor.
+     * @param opidx Indexes of the OUT params.
+     *  <b>Index count starts from 1</b>.
+     */
+    public StoredProcedureOutcome(final int... opidx) {
+        if (opidx == null || opidx.length == 0) {
+            throw new IllegalArgumentException(
+                "At least 1 OUT param's index nees to be specified!"
+            );
+        }
+        final int size = opidx.length;
+        this.outpidx = new int[size];
+        for (int idx = 0; idx < size; ++idx) {
+            this.outpidx[idx] = opidx[idx];
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T handle(
+        final ResultSet rset, final Statement stmt
+    ) throws SQLException {
+        final int nrop = this.outpidx.length;
+        final Object[] outs = new Object[nrop];
+        if (stmt instanceof CallableStatement) {
+            for (int idx = 0; idx < nrop; ++idx) {
+                outs[idx] = ((CallableStatement) stmt).getObject(
+                    this.outpidx[idx]
+                );
+            }
+        }
+        return (T) outs;
+    }
+
+}

--- a/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
@@ -41,35 +41,35 @@ import lombok.ToString;
  * Outcome of a stored procedure with OUT parameters.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.7
+ * @since 0.17
  * @param <T> Type of items
  */
 @Immutable
 @ToString
-@EqualsAndHashCode(of = { "outpidx" })
+@EqualsAndHashCode(of = "indexes")
 public final class StoredProcedureOutcome<T> implements Outcome<T> {
 
     /**
-     * Indexes of the OUT params.
+     * OUT parameters' indexes.
      */
     @Immutable.Array
-    private final transient int[] outpidx;
+    private final transient int[] indexes;
 
     /**
      * Ctor.
-     * @param nrop Number of OUT params. Has to be > 0.
+     * @param nrofparams Number of OUT params. Has to be > 0.
      *  If this ctor is used, it is assumed that the OUT parameters
      *  are from index 1 to including nrop.
      */
-    public StoredProcedureOutcome(final int nrop) {
-        if (nrop <= 0) {
+    public StoredProcedureOutcome(final int nrofparams) {
+        if (nrofparams <= 0) {
             throw new IllegalArgumentException(
                 "Nr of out params has to be a positive int!"
             );
         }
-        this.outpidx = new int[nrop];
-        for (int idx = 0; idx < nrop; ++idx) {
-            this.outpidx[idx] = idx + 1;
+        this.indexes = new int[nrofparams];
+        for (int idx = 0; idx < nrofparams; ++idx) {
+            this.indexes[idx] = idx + 1;
         }
     }
 
@@ -79,29 +79,28 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
      *  <b>Index count starts from 1</b>.
      */
     public StoredProcedureOutcome(final int... opidx) {
-        if (opidx == null || opidx.length == 0) {
+        if (opidx.length == 0) {
             throw new IllegalArgumentException(
                 "At least 1 OUT param's index needs to be specified!"
             );
         }
         final int size = opidx.length;
-        this.outpidx = new int[size];
+        this.indexes = new int[size];
         for (int idx = 0; idx < size; ++idx) {
-            this.outpidx[idx] = opidx[idx];
+            this.indexes[idx] = opidx[idx];
         }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public T handle(
-        final ResultSet rset, final Statement stmt
-    ) throws SQLException {
-        final int nrop = this.outpidx.length;
-        final Object[] outs = new Object[nrop];
+        final ResultSet rset, final Statement stmt) throws SQLException {
+        final int nroutparams = this.indexes.length;
+        final Object[] outs = new Object[nroutparams];
         if (stmt instanceof CallableStatement) {
-            for (int idx = 0; idx < nrop; ++idx) {
+            for (int idx = 0; idx < nroutparams; ++idx) {
                 outs[idx] = ((CallableStatement) stmt).getObject(
-                    this.outpidx[idx]
+                    this.indexes[idx]
                 );
             }
         }

--- a/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
@@ -57,24 +57,6 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
 
     /**
      * Ctor.
-     * @param params Number of OUT params. Has to be > 0.
-     *  If this ctor is used, it is assumed that the OUT parameters
-     *  are from index 1 to including nrop.
-     */
-    public StoredProcedureOutcome(final int params) {
-        if (params <= 0) {
-            throw new IllegalArgumentException(
-                "Nr of out params has to be a positive int!"
-            );
-        }
-        this.indexes = new int[params];
-        for (int idx = 0; idx < params; ++idx) {
-            this.indexes[idx] = idx + 1;
-        }
-    }
-
-    /**
-     * Ctor.
      * @param indexes Indexes of the OUT params.
      *  <b>Index count starts from 1</b>.
      */
@@ -93,8 +75,8 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public T handle(
-        final ResultSet rset, final Statement stmt) throws SQLException {
+    public T handle(final ResultSet rset, final Statement stmt)
+        throws SQLException {
         final int params = this.indexes.length;
         final Object[] outs = new Object[params];
         if (stmt instanceof CallableStatement) {

--- a/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
@@ -81,7 +81,7 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
     public StoredProcedureOutcome(final int... opidx) {
         if (opidx == null || opidx.length == 0) {
             throw new IllegalArgumentException(
-                "At least 1 OUT param's index nees to be specified!"
+                "At least 1 OUT param's index needs to be specified!"
             );
         }
         final int size = opidx.length;

--- a/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
@@ -57,37 +57,37 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
 
     /**
      * Ctor.
-     * @param nrofparams Number of OUT params. Has to be > 0.
+     * @param params Number of OUT params. Has to be > 0.
      *  If this ctor is used, it is assumed that the OUT parameters
      *  are from index 1 to including nrop.
      */
-    public StoredProcedureOutcome(final int nrofparams) {
-        if (nrofparams <= 0) {
+    public StoredProcedureOutcome(final int params) {
+        if (params <= 0) {
             throw new IllegalArgumentException(
                 "Nr of out params has to be a positive int!"
             );
         }
-        this.indexes = new int[nrofparams];
-        for (int idx = 0; idx < nrofparams; ++idx) {
+        this.indexes = new int[params];
+        for (int idx = 0; idx < params; ++idx) {
             this.indexes[idx] = idx + 1;
         }
     }
 
     /**
      * Ctor.
-     * @param opidx Indexes of the OUT params.
+     * @param indexes Indexes of the OUT params.
      *  <b>Index count starts from 1</b>.
      */
-    public StoredProcedureOutcome(final int... opidx) {
-        if (opidx.length == 0) {
+    public StoredProcedureOutcome(final int... indexes) {
+        if (indexes.length == 0) {
             throw new IllegalArgumentException(
                 "At least 1 OUT param's index needs to be specified!"
             );
         }
-        final int size = opidx.length;
+        final int size = indexes.length;
         this.indexes = new int[size];
         for (int idx = 0; idx < size; ++idx) {
-            this.indexes[idx] = opidx[idx];
+            this.indexes[idx] = indexes[idx];
         }
     }
 
@@ -95,10 +95,10 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
     @SuppressWarnings("unchecked")
     public T handle(
         final ResultSet rset, final Statement stmt) throws SQLException {
-        final int nroutparams = this.indexes.length;
-        final Object[] outs = new Object[nroutparams];
+        final int params = this.indexes.length;
+        final Object[] outs = new Object[params];
         if (stmt instanceof CallableStatement) {
-            for (int idx = 0; idx < nroutparams; ++idx) {
+            for (int idx = 0; idx < params; ++idx) {
                 outs[idx] = ((CallableStatement) stmt).getObject(
                     this.indexes[idx]
                 );

--- a/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
@@ -42,7 +42,7 @@ import lombok.ToString;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.17
- * @param <T> Type of items
+ * @param <T> Type of the returned result, which <b>has to be</b> Object[]
  */
 @Immutable
 @ToString
@@ -91,6 +91,10 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
         }
     }
 
+    /**
+     * Handles the OUT parameter(s) of a stored procedure call and returns
+     * them as <b>Object[]</b>. Therefore, T has to be <b>Object[]</b>.
+     */
     @Override
     @SuppressWarnings("unchecked")
     public T handle(

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
@@ -47,7 +47,6 @@ import org.junit.Test;
  * Integration case for {@link JdbcSession}.
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
- * @checkstyle StringLiteralsConcatenationCheck (300 lines)
  */
 public final class JdbcSessionITCase {
 

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
@@ -110,13 +110,13 @@ public final class JdbcSessionITCase {
         ).execute().sql("INSERT INTO users (name) VALUES (?)")
         .set("Jeff Charles").execute().sql(
             StringUtils.join(
-                "CREATE OR REPLACE FUNCTION getUser(username OUT text)",
+                "CREATE OR REPLACE FUNCTION user(username OUT text)",
                 " AS $$ BEGIN SELECT name INTO username from  users; END;",
                 " $$ LANGUAGE plpgsql;"
             )
         ).execute().commit();
         final Object[] result = new JdbcSession(dsrc)
-            .sql("{call getUser(?)}")
+            .sql("{call user(?)}")
             .prepare(
                 new Preparation() {
                     @Override
@@ -148,14 +148,14 @@ public final class JdbcSessionITCase {
         ).execute().sql("INSERT INTO usersid (id, name) VALUES (?, ?)")
         .set(1).set("Marco Polo").execute().sql(
             StringUtils.join(
-                "CREATE OR REPLACE FUNCTION getUserById(uid IN INTEGER,",
+                "CREATE OR REPLACE FUNCTION userById(uid IN INTEGER,",
                 " usrnm OUT text) AS $$ BEGIN",
                 " SELECT name INTO usrnm FROM  usersid WHERE id=uid;",
                 " END; $$ LANGUAGE plpgsql;"
             )
         ).execute().commit();
         final Object[] result = new JdbcSession(dsrc)
-            .sql("{call getUserById(?, ?)}")
+            .sql("{call userById(?, ?)}")
             .set(1)
             .prepare(
                 new Preparation() {

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
@@ -159,7 +159,7 @@ public final class JdbcSessionITCase {
             StringUtils.join(
                 "CREATE OR REPLACE FUNCTION fetchUserById(uid IN INTEGER,",
                 " usrnm OUT text) AS $$ BEGIN",
-                " SELECT name INTO usrnm FROM  usersids WHERE id=uid;",
+                " SELECT name INTO usrnm FROM usersids WHERE id=uid;",
                 " END; $$ LANGUAGE plpgsql;"
             )
         ).execute().commit();

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
@@ -36,6 +36,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 import javax.sql.DataSource;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
@@ -109,9 +110,11 @@ public final class JdbcSessionITCase {
             "CREATE TABLE IF NOT EXISTS users (name VARCHAR(50))"
         ).execute().sql("INSERT INTO users (name) VALUES (?)")
         .set("Jeff Charles").execute().sql(
-            "CREATE OR REPLACE FUNCTION getUser(username OUT text)"
-            + " AS $$ BEGIN SELECT name INTO username from  users; END;"
-            + " $$ LANGUAGE plpgsql;"
+            StringUtils.join(
+                "CREATE OR REPLACE FUNCTION getUser(username OUT text)",
+                " AS $$ BEGIN SELECT name INTO username from  users; END;",
+                " $$ LANGUAGE plpgsql;"
+            )
         ).execute().commit();
         final Object[] result = new JdbcSession(dsrc)
             .sql("{call getUser(?)}")
@@ -119,8 +122,7 @@ public final class JdbcSessionITCase {
                 new Preparation() {
                     @Override
                     public void prepare(
-                        final PreparedStatement stmt
-                    ) throws SQLException {
+                        final PreparedStatement stmt) throws SQLException {
                         ((CallableStatement) stmt)
                             .registerOutParameter(1, Types.VARCHAR);
                     }
@@ -146,10 +148,12 @@ public final class JdbcSessionITCase {
             "CREATE TABLE IF NOT EXISTS usersid (id INTEGER, name VARCHAR(50))"
         ).execute().sql("INSERT INTO usersid (id, name) VALUES (?, ?)")
         .set(1).set("Marco Polo").execute().sql(
-            "CREATE OR REPLACE FUNCTION getUserById(uid IN INTEGER,"
-            + " usrnm OUT text) AS $$ BEGIN"
-            + " SELECT name INTO usrnm FROM  usersid WHERE id=uid;"
-            + " END; $$ LANGUAGE plpgsql;"
+            StringUtils.join(
+                "CREATE OR REPLACE FUNCTION getUserById(uid IN INTEGER,",
+                " usrnm OUT text) AS $$ BEGIN",
+                " SELECT name INTO usrnm FROM  usersid WHERE id=uid;",
+                " END; $$ LANGUAGE plpgsql;"
+            )
         ).execute().commit();
         final Object[] result = new JdbcSession(dsrc)
             .sql("{call getUserById(?, ?)}")
@@ -158,8 +162,7 @@ public final class JdbcSessionITCase {
                 new Preparation() {
                     @Override
                     public void prepare(
-                        final PreparedStatement stmt
-                    ) throws SQLException {
+                        final PreparedStatement stmt) throws SQLException {
                         ((CallableStatement) stmt)
                             .registerOutParameter(2, Types.VARCHAR);
                     }

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
@@ -114,7 +114,7 @@ public final class JdbcSessionITCase {
                 "CREATE OR REPLACE FUNCTION fetchUser(username OUT text,",
                 " day OUT date)",
                 " AS $$ BEGIN SELECT name, CURRENT_DATE INTO username, day",
-                " FROM  users; END; $$ LANGUAGE plpgsql;"
+                " FROM users; END; $$ LANGUAGE plpgsql;"
             )
         ).execute().commit();
         final Object[] result = new JdbcSession(source)
@@ -132,7 +132,7 @@ public final class JdbcSessionITCase {
                     }
                 }
              )
-            .call(new StoredProcedureOutcome<Object[]>(2));
+            .call(new StoredProcedureOutcome<Object[]>(1, 2));
         MatcherAssert.assertThat(result.length, Matchers.is(2));
         MatcherAssert.assertThat(
             result[0].toString(),
@@ -153,13 +153,13 @@ public final class JdbcSessionITCase {
     public void callsFunctionWithInOutParam() throws Exception {
         final DataSource source = JdbcSessionITCase.source();
         new JdbcSession(source).autocommit(false).sql(
-            "CREATE TABLE IF NOT EXISTS usersid (id INTEGER, name VARCHAR(50))"
-        ).execute().sql("INSERT INTO usersid (id, name) VALUES (?, ?)")
+            "CREATE TABLE IF NOT EXISTS usersids (id INTEGER, name VARCHAR(50))"
+        ).execute().sql("INSERT INTO usersids (id, name) VALUES (?, ?)")
         .set(1).set("Marco Polo").execute().sql(
             StringUtils.join(
                 "CREATE OR REPLACE FUNCTION fetchUserById(uid IN INTEGER,",
                 " usrnm OUT text) AS $$ BEGIN",
-                " SELECT name INTO usrnm FROM  usersid WHERE id=uid;",
+                " SELECT name INTO usrnm FROM  usersids WHERE id=uid;",
                 " END; $$ LANGUAGE plpgsql;"
             )
         ).execute().commit();
@@ -177,7 +177,7 @@ public final class JdbcSessionITCase {
                     }
                 }
              )
-            .call(new StoredProcedureOutcome<Object[]>(new int[] {2}));
+            .call(new StoredProcedureOutcome<Object[]>(2));
         MatcherAssert.assertThat(result.length, Matchers.is(1));
         MatcherAssert.assertThat(
             result[0].toString(),

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
@@ -122,8 +122,9 @@ public final class JdbcSessionITCase {
             .prepare(
                 new Preparation() {
                     @Override
-                    public void prepare(
-                        final PreparedStatement stmt) throws SQLException {
+                    public void
+                        prepare(final PreparedStatement stmt)
+                        throws SQLException {
                             final CallableStatement cstmt =
                                 (CallableStatement) stmt;
                             cstmt.registerOutParameter(1, Types.VARCHAR);
@@ -168,10 +169,11 @@ public final class JdbcSessionITCase {
             .prepare(
                 new Preparation() {
                     @Override
-                    public void prepare(
-                        final PreparedStatement stmt) throws SQLException {
-                        ((CallableStatement) stmt)
-                            .registerOutParameter(2, Types.VARCHAR);
+                    public void
+                        prepare(final PreparedStatement stmt)
+                        throws SQLException {
+                            ((CallableStatement) stmt)
+                                .registerOutParameter(2, Types.VARCHAR);
                     }
                 }
              )

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
@@ -110,13 +110,13 @@ public final class JdbcSessionITCase {
         ).execute().sql("INSERT INTO users (name) VALUES (?)")
         .set("Jeff Charles").execute().sql(
             StringUtils.join(
-                "CREATE OR REPLACE FUNCTION user(username OUT text)",
+                "CREATE OR REPLACE FUNCTION fetchUser(username OUT text)",
                 " AS $$ BEGIN SELECT name INTO username from  users; END;",
                 " $$ LANGUAGE plpgsql;"
             )
         ).execute().commit();
         final Object[] result = new JdbcSession(dsrc)
-            .sql("{call user(?)}")
+            .sql("{call fetchUser(?)}")
             .prepare(
                 new Preparation() {
                     @Override
@@ -148,14 +148,14 @@ public final class JdbcSessionITCase {
         ).execute().sql("INSERT INTO usersid (id, name) VALUES (?, ?)")
         .set(1).set("Marco Polo").execute().sql(
             StringUtils.join(
-                "CREATE OR REPLACE FUNCTION userById(uid IN INTEGER,",
+                "CREATE OR REPLACE FUNCTION fetchUserById(uid IN INTEGER,",
                 " usrnm OUT text) AS $$ BEGIN",
                 " SELECT name INTO usrnm FROM  usersid WHERE id=uid;",
                 " END; $$ LANGUAGE plpgsql;"
             )
         ).execute().commit();
         final Object[] result = new JdbcSession(dsrc)
-            .sql("{call userById(?, ?)}")
+            .sql("{call fetchUserById(?, ?)}")
             .set(1)
             .prepare(
                 new Preparation() {


### PR DESCRIPTION
PR for #51 .
Added Outcome and Connect that provide calling stored procedure functionality. 
**E.g 1.**
Say you have a stored procedure which takes 1 INPUT and 1 OUTPUT, this is how you would use the API to call it: 

```
final Object[] result = new JdbcSession(dsrc)
            .sql("{call getUserById(?, ?)}")
            .set(1)
            .prepare(
                new Preparation() {
                    @Override
                    public void prepare(
                        final PreparedStatement stmt
                    ) throws SQLException {
                        ((CallableStatement) stmt)
                            .registerOutParameter(2, Types.VARCHAR);
                    }
                }
             )
            .call(new StoredProcedureOutcome<Object[]>(2));
```

Unlike `execute()` and others, `JdbcSession.call(Outcome)` opens a `CallableStatement`, instead of a `PreparedStatement`. Output parameters need to be registered by providing a `Preparation` .

**E.g. 2:**

If you have IN and OUT Params together, let's say in the following order:
`IN, OUT, IN, OUT`, then you have to use the `Outcome` as follows:
`new StoredProcedureOutcome<Object[]>(2, 4)`
