### PR TITLE
Removed JdbcSession ctor for Connection

### DIFF
--- a/src/main/java/com/jcabi/jdbc/JdbcSession.java
+++ b/src/main/java/com/jcabi/jdbc/JdbcSession.java
@@ -100,7 +100,7 @@ import lombok.ToString;
  *   .autocommit(false)
  *   .sql("SHUTDOWN COMPACT")
  *   .execute();</pre>
- * 
+ *
  * <b>IMPORTANT:</b>
  * <p>If you rely on one specific {@link Connection} instance, be careful if
  * you are using it in more places, especially if more references of this class
@@ -118,7 +118,7 @@ import lombok.ToString;
  *  .sql("SQL STATEMENT 2")
  *  .execute();</pre>
  * <p>The above example will <b>fail</b> because the first JdbcSession closes
- * the connection, and the next one tries to work with it closed. In order to 
+ * the connection, and the next one tries to work with it closed. In order to
  * not have this failure, the first session has to call
  * {@link #autocommit(false)}, like this:
  * </p>

--- a/src/main/java/com/jcabi/jdbc/JdbcSession.java
+++ b/src/main/java/com/jcabi/jdbc/JdbcSession.java
@@ -162,15 +162,6 @@ public final class JdbcSession {
     }
 
     /**
-     * Public ctor.
-     * @param cnx Connection to use
-     * @since 0.10
-     */
-    public JdbcSession(final Connection cnx) {
-        this(new StaticSource(cnx));
-    }
-
-    /**
      * Use this SQL query (with optional parameters inside).
      *
      * <p>The query will be used in {@link PreparedStatement}, that's why

--- a/src/main/java/com/jcabi/jdbc/StaticSource.java
+++ b/src/main/java/com/jcabi/jdbc/StaticSource.java
@@ -37,7 +37,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * Static data source which wraps a single {@link Connection}
+ * Static data source which wraps a single {@link Connection}.
  *
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$

--- a/src/main/java/com/jcabi/jdbc/StaticSource.java
+++ b/src/main/java/com/jcabi/jdbc/StaticSource.java
@@ -37,7 +37,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /**
- * Static data source.
+ * Static data source which wraps a single {@link Connection}
  *
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
@@ -45,7 +45,7 @@ import lombok.ToString;
  */
 @ToString
 @EqualsAndHashCode(of = "conn")
-final class StaticSource implements DataSource {
+public final class StaticSource implements DataSource {
 
     /**
      * The connection.
@@ -56,7 +56,7 @@ final class StaticSource implements DataSource {
      * Public ctor.
      * @param cnx Connection
      */
-    StaticSource(final Connection cnx) {
+    public StaticSource(final Connection cnx) {
         this.conn = cnx;
     }
 


### PR DESCRIPTION
PR for #54 
Please read the ticket discussion carefully to make sure we have the same understanding.

As the author pointed out, it's not ok that JdbcSession closes a Connection the client gives to it (according to the principle that a blackbox should not alter resources given from outside)

The JdbcSession offers the possibility to not close/autocommit the connection if the client specifies ``JdbcSession.autocommit(false)``, but that only works if all the method calls are done with the same ``JdbcSession`` reference. Or if you use more references, you have to make sure all of them call ``.autocommit(false)``, which is terrible coupling

This would fail:
```
new JdbcSession(connection)
   .sql("SQL STATEMENT")
   .execute();
new JdbcSession(connection)
   .sql("SQL STATEMENT 2")
   .execute();
```

One option to fix this is to reverse the autocommit mechanism (right now autocommit/close is done by default and stopped if the user says so).

However, this option ruins backwards compatibility more than simply removing the Connection ctor. Think about the bugs we'd introduce if we simply switch the mechanism. It's better if the user simply sees a red complation failure and provides a ``DataSource``.