### PR TITLE
Upgrade dependencies and qulice 0.27.5; fix new lint issues

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,12 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.44</version>
+      <version>1.18.46</version>
     </dependency>
     <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjrt</artifactId>
-      <version>1.9.25</version>
+      <version>1.9.25.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -92,19 +92,19 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.3.232</version>
+      <version>2.4.240</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.10</version>
+      <version>42.7.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
-      <version>9.6.0</version>
+      <version>9.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>2.0.3</version>
+      <version>2.0.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.25.3</version>
+      <version>2.25.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -254,7 +254,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.27.5</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>duplicatefinder:.*</exclude>

--- a/src/main/java/com/jcabi/jdbc/ColumnOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/ColumnOutcome.java
@@ -39,17 +39,7 @@ public final class ColumnOutcome<T> implements Outcome<Collection<T>> {
     private final Mapping<T> mapping;
 
     /**
-     * Primary ctor.
-     *
-     * @param mpp The mapping
-     */
-    public ColumnOutcome(final Mapping<T> mpp) {
-        this.mapping = mpp;
-    }
-
-    /**
      * Public ctor.
-     *
      * @param type The type to convert to
      */
     public ColumnOutcome(final Class<T> type) {
@@ -58,12 +48,20 @@ public final class ColumnOutcome<T> implements Outcome<Collection<T>> {
 
     /**
      * Public ctor.
-     *
      * @param type The type to convert to
-     * @param mps The mappings.
+     * @param mps The mappings
      */
+    // @checkstyle ConstructorsCodeFreeCheck (3 lines)
     public ColumnOutcome(final Class<T> type, final Mappings mps) {
         this(mps.forType(type));
+    }
+
+    /**
+     * Primary ctor.
+     * @param mpp The mapping
+     */
+    public ColumnOutcome(final Mapping<T> mpp) {
+        this.mapping = mpp;
     }
 
     @Override
@@ -75,5 +73,4 @@ public final class ColumnOutcome<T> implements Outcome<Collection<T>> {
         }
         return result;
     }
-
 }

--- a/src/main/java/com/jcabi/jdbc/Connect.java
+++ b/src/main/java/com/jcabi/jdbc/Connect.java
@@ -11,7 +11,6 @@ import java.sql.Statement;
 
 /**
  * Connect.
- *
  * @since 0.13
  */
 @FunctionalInterface
@@ -19,7 +18,6 @@ interface Connect {
 
     /**
      * Create prepare statement.
-     *
      * @param conn Open connection
      * @return The statement
      * @throws SQLException If some problem
@@ -29,10 +27,10 @@ interface Connect {
     /**
      * Connect which opens a <b>CallableStatement</b>, which
      * is used for calling stored procedures.
-     *
      * @since 0.13
      */
     final class Call implements Connect {
+
         /**
          * SQL function call.
          */
@@ -40,7 +38,6 @@ interface Connect {
 
         /**
          * Ctor.
-         *
          * @param query Query
          */
         Call(final String query) {
@@ -55,10 +52,10 @@ interface Connect {
 
     /**
      * Plain, without keys.
-     *
      * @since 0.13
      */
     final class Plain implements Connect {
+
         /**
          * SQL query.
          */
@@ -66,7 +63,6 @@ interface Connect {
 
         /**
          * Ctor.
-         *
          * @param query Query
          */
         Plain(final String query) {
@@ -81,10 +77,10 @@ interface Connect {
 
     /**
      * With returned keys.
-     *
      * @since 0.13
      */
     final class WithKeys implements Connect {
+
         /**
          * SQL query.
          */
@@ -92,7 +88,6 @@ interface Connect {
 
         /**
          * Ctor.
-         *
          * @param query Query
          */
         WithKeys(final String query) {
@@ -107,5 +102,4 @@ interface Connect {
             );
         }
     }
-
 }

--- a/src/main/java/com/jcabi/jdbc/DefaultMappings.java
+++ b/src/main/java/com/jcabi/jdbc/DefaultMappings.java
@@ -14,23 +14,14 @@ import java.util.stream.Stream;
 
 /**
  * Default mappings for types.
- *
  * @since 0.17.6
  */
 final class DefaultMappings implements Outcome.Mappings {
+
     /**
      * Per-type extraction methods.
      */
     private final Map<Class<?>, Outcome.Mapping<?>> map;
-
-    /**
-     * Primary ctor.
-     *
-     * @param mpp The mappings map
-     */
-    private DefaultMappings(final Map<Class<?>, Outcome.Mapping<?>> mpp) {
-        this.map = mpp;
-    }
 
     /**
      * Ctor.
@@ -41,11 +32,39 @@ final class DefaultMappings implements Outcome.Mappings {
 
     /**
      * Ctor.
-     *
-     * @param column Column position.
+     * @param column Column position
      */
+    // @checkstyle ConstructorsCodeFreeCheck (3 lines)
     DefaultMappings(final int column) {
-        this(
+        this(DefaultMappings.defaults(column));
+    }
+
+    /**
+     * Primary ctor.
+     * @param mpp The mappings map
+     */
+    private DefaultMappings(final Map<Class<?>, Outcome.Mapping<?>> mpp) {
+        this.map = mpp;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <X> Outcome.Mapping<X> forType(final Class<? extends X> type) {
+        if (!this.map.containsKey(type)) {
+            throw new IllegalArgumentException(
+                String.format("Type %s is not supported", type.getName())
+            );
+        }
+        return (Outcome.Mapping<X>) this.map.get(type);
+    }
+
+    /**
+     * Build the default mappings for a given column.
+     * @param column Column position
+     * @return The default mappings map
+     */
+    private static Map<Class<?>, Outcome.Mapping<?>> defaults(final int column) {
+        return Stream.<Map.Entry<Class<?>, Outcome.Mapping<?>>>of(
             new AbstractMap.SimpleImmutableEntry<>(
                 String.class, rs -> rs.getString(column)
             ),
@@ -73,38 +92,8 @@ final class DefaultMappings implements Outcome.Mappings {
             new AbstractMap.SimpleImmutableEntry<>(
                 UUID.class, rs -> rs.getObject(column, UUID.class)
             )
+        ).collect(
+            Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)
         );
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param mappings Mappings.
-     */
-    @SafeVarargs
-    private DefaultMappings(
-        final Map.Entry<Class<?>, Outcome.Mapping<?>>... mappings
-    ) {
-        this(
-            Stream
-                .of(mappings)
-                .collect(
-                    Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue
-                    )
-                )
-        );
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <X> Outcome.Mapping<X> forType(final Class<? extends X> type) {
-        if (!this.map.containsKey(type)) {
-            throw new IllegalArgumentException(
-                String.format("Type %s is not supported", type.getName())
-            );
-        }
-        return (Outcome.Mapping<X>) this.map.get(type);
     }
 }

--- a/src/main/java/com/jcabi/jdbc/JdbcSession.java
+++ b/src/main/java/com/jcabi/jdbc/JdbcSession.java
@@ -173,6 +173,7 @@ public final class JdbcSession {
      *
      * @param src Data source
      */
+    // @checkstyle ConstructorsCodeFreeCheck (10 lines)
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public JdbcSession(final DataSource src) {
         this.args = new LinkedList<>();
@@ -246,7 +247,6 @@ public final class JdbcSession {
 
     /**
      * Run this preparation before executing the statement.
-     *
      * @param prp Preparation
      * @return This object
      * @since 0.13
@@ -260,7 +260,6 @@ public final class JdbcSession {
 
     /**
      * Clear all pre-set parameters (args, preparations, etc).
-     *
      * @return This object
      * @since 0.13
      */
@@ -276,7 +275,6 @@ public final class JdbcSession {
     /**
      * Commit the transaction (calls {@link Connection#commit()} and then
      * {@link Connection#close()}).
-     *
      * @throws SQLException If fails to do the SQL operation
      */
     public void commit() throws SQLException {
@@ -293,7 +291,6 @@ public final class JdbcSession {
     /**
      * Rollback the transaction (calls {@link Connection#rollback()} and then
      * {@link Connection#close()}).
-     *
      * @throws SQLException If fails to do the SQL operation
      */
     public void rollback() throws SQLException {
@@ -320,8 +317,7 @@ public final class JdbcSession {
      * @return The result
      * @throws SQLException If fails
      */
-    public <T> T insert(final Outcome<T> outcome)
-        throws SQLException {
+    public <T> T insert(final Outcome<T> outcome) throws SQLException {
         return this.run(
             outcome,
             new Connect.WithKeys(this.query),
@@ -339,8 +335,7 @@ public final class JdbcSession {
      * @return This object
      * @throws SQLException If fails
      */
-    public <T> T update(final Outcome<T> outcome)
-        throws SQLException {
+    public <T> T update(final Outcome<T> outcome) throws SQLException {
         return this.run(
             outcome,
             new Connect.WithKeys(this.query),
@@ -361,8 +356,7 @@ public final class JdbcSession {
      * @return Result of type T
      * @throws SQLException If fails
      */
-    public <T> T call(final Outcome<T> outcome)
-        throws SQLException {
+    public <T> T call(final Outcome<T> outcome) throws SQLException {
         return this.run(
             outcome, new Connect.Call(this.query), Request.EXECUTE_UPDATE
         );
@@ -409,8 +403,7 @@ public final class JdbcSession {
      * @return The result
      * @throws SQLException If fails
      */
-    public <T> T select(final Outcome<T> outcome)
-        throws SQLException {
+    public <T> T select(final Outcome<T> outcome) throws SQLException {
         return this.run(
             outcome,
             new Connect.Plain(this.query),
@@ -420,7 +413,6 @@ public final class JdbcSession {
 
     /**
      * Run with this outcome, and this fetcher.
-     *
      * @param outcome The outcome of the operation
      * @param connect Connect
      * @param request Request
@@ -500,7 +492,6 @@ public final class JdbcSession {
 
     /**
      * Open connection and cache it locally in the class.
-     *
      * @return Connection to use
      * @throws SQLException If fails
      */
@@ -515,7 +506,6 @@ public final class JdbcSession {
 
     /**
      * Close connection if it's open (runtime exception otherwise).
-     *
      * @throws SQLException If fails to do the SQL operation
      */
     private void disconnect() throws SQLException {
@@ -530,7 +520,6 @@ public final class JdbcSession {
 
     /**
      * Configure the statement.
-     *
      * @param stmt Statement
      * @throws SQLException If fails
      */
@@ -539,5 +528,4 @@ public final class JdbcSession {
             prep.prepare(stmt);
         }
     }
-
 }

--- a/src/main/java/com/jcabi/jdbc/ListOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/ListOutcome.java
@@ -59,5 +59,4 @@ public final class ListOutcome<T> implements Outcome<List<T>> {
         }
         return result;
     }
-
 }

--- a/src/main/java/com/jcabi/jdbc/Outcome.java
+++ b/src/main/java/com/jcabi/jdbc/Outcome.java
@@ -87,14 +87,12 @@ public interface Outcome<T> {
 
     /**
      * Default mappings.
-     *
      * @since 0.17.6
      */
     Mappings DEFAULT_MAPPINGS = new DefaultMappings();
 
     /**
      * Process the result set and return some value.
-     *
      * @param rset The result set to process
      * @param stmt The statement used in the run
      * @return The result
@@ -104,15 +102,14 @@ public interface Outcome<T> {
 
     /**
      * Mapping.
-     *
      * @param <T> Type of output
      * @since 0.13
      */
     @FunctionalInterface
     interface Mapping<T> {
+
         /**
          * Map.
-         *
          * @param rset Result set
          * @return Object
          * @throws SQLException If fails
@@ -122,17 +119,16 @@ public interface Outcome<T> {
 
     /**
      * Mappings for different types.
-     *
      * @since 0.17.6
      */
     @FunctionalInterface
     interface Mappings {
+
         /**
          * Mapping for a type.
-         *
-         * @param type Class of result.
-         * @param <T> Type of result.
-         * @return Mapping.
+         * @param type Class of result
+         * @param <T> Type of result
+         * @return Mapping
          */
         <T> Mapping<T> forType(Class<? extends T> type);
     }

--- a/src/main/java/com/jcabi/jdbc/Preparation.java
+++ b/src/main/java/com/jcabi/jdbc/Preparation.java
@@ -9,7 +9,6 @@ import java.sql.SQLException;
 
 /**
  * Preparation of a {@link java.sql.PreparedStatement}.
- *
  * @since 0.13
  */
 @FunctionalInterface
@@ -22,5 +21,4 @@ public interface Preparation {
      * @since 0.12
      */
     void prepare(PreparedStatement stmt) throws SQLException;
-
 }

--- a/src/main/java/com/jcabi/jdbc/PrepareArgs.java
+++ b/src/main/java/com/jcabi/jdbc/PrepareArgs.java
@@ -9,11 +9,9 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
-import java.util.Collections;
 
 /**
  * Prepare arguments.
- *
  * @since 0.13
  */
 final class PrepareArgs implements Preparation {
@@ -28,7 +26,7 @@ final class PrepareArgs implements Preparation {
      * @param arguments Arguments
      */
     PrepareArgs(final Collection<Object> arguments) {
-        this.args = Collections.unmodifiableCollection(arguments);
+        this.args = arguments;
     }
 
     @Override

--- a/src/main/java/com/jcabi/jdbc/Request.java
+++ b/src/main/java/com/jcabi/jdbc/Request.java
@@ -10,7 +10,6 @@ import java.sql.SQLException;
 
 /**
  * Request.
- *
  * @since 0.13
  */
 @FunctionalInterface
@@ -58,5 +57,4 @@ interface Request {
      * @throws SQLException If some problem
      */
     ResultSet fetch(PreparedStatement stmt) throws SQLException;
-
 }

--- a/src/main/java/com/jcabi/jdbc/SingleOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/SingleOutcome.java
@@ -56,19 +56,7 @@ public final class SingleOutcome<T> implements Outcome<T> {
     private final boolean silently;
 
     /**
-     * Primary ctor.
-     *
-     * @param mpp The mapping
-     * @param slnt Silently return NULL if there is no row
-     */
-    public SingleOutcome(final Mapping<? extends T> mpp, final boolean slnt) {
-        this.mapping = mpp;
-        this.silently = slnt;
-    }
-
-    /**
      * Public ctor.
-     *
      * @param type The type to convert to
      */
     public SingleOutcome(final Class<T> type) {
@@ -77,7 +65,6 @@ public final class SingleOutcome<T> implements Outcome<T> {
 
     /**
      * Public ctor.
-     *
      * @param type The type to convert to
      * @param slnt Silently return NULL if there is no row
      */
@@ -91,13 +78,23 @@ public final class SingleOutcome<T> implements Outcome<T> {
 
     /**
      * Public ctor.
-     *
      * @param type The type to convert to
      * @param mps The mappings
      * @param slnt Silently return NULL if there is no row
      */
+    // @checkstyle ConstructorsCodeFreeCheck (3 lines)
     public SingleOutcome(final Class<T> type, final Mappings mps, final boolean slnt) {
         this(mps.forType(type), slnt);
+    }
+
+    /**
+     * Primary ctor.
+     * @param mpp The mapping
+     * @param slnt Silently return NULL if there is no row
+     */
+    public SingleOutcome(final Mapping<? extends T> mpp, final boolean slnt) {
+        this.mapping = mpp;
+        this.silently = slnt;
     }
 
     @Override
@@ -114,7 +111,6 @@ public final class SingleOutcome<T> implements Outcome<T> {
 
     /**
      * Fetch the value from result set.
-     *
      * @param rset Result set
      * @return The result
      * @throws SQLException If some error inside

--- a/src/main/java/com/jcabi/jdbc/StaticSource.java
+++ b/src/main/java/com/jcabi/jdbc/StaticSource.java
@@ -13,7 +13,6 @@ import lombok.ToString;
 
 /**
  * Static data source which wraps a single {@link Connection}.
- *
  * @since 0.10
  */
 @ToString
@@ -78,5 +77,4 @@ public final class StaticSource implements DataSource {
     public boolean isWrapperFor(final Class<?> iface) {
         throw new UnsupportedOperationException("#isWrapperFor()");
     }
-
 }

--- a/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
+++ b/src/main/java/com/jcabi/jdbc/StoredProcedureOutcome.java
@@ -27,8 +27,8 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
 
     /**
      * Ctor.
-     * @param indexes Indexes of the OUT params.
-     *  <b>Index count starts from 1</b>.
+     * @param indexes Indexes of the OUT params
+     *  &lt;b&gt;Index count starts from 1&lt;/b&gt;
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public StoredProcedureOutcome(final int... indexes) {
@@ -59,5 +59,4 @@ public final class StoredProcedureOutcome<T> implements Outcome<T> {
         }
         return (T) outs;
     }
-
 }

--- a/src/main/java/com/jcabi/jdbc/UrlSource.java
+++ b/src/main/java/com/jcabi/jdbc/UrlSource.java
@@ -15,7 +15,6 @@ import lombok.ToString;
 
 /**
  * Data source when all you have is a URL.
- *
  * @since 0.19.0
  */
 @ToString
@@ -29,7 +28,7 @@ public final class UrlSource implements DataSource {
 
     /**
      * Public ctor.
-     * @param jdbc The JDBC URL.
+     * @param jdbc The JDBC URL
      */
     public UrlSource(final String jdbc) {
         this.url = jdbc;
@@ -84,5 +83,4 @@ public final class UrlSource implements DataSource {
     public boolean isWrapperFor(final Class<?> iface) {
         throw new UnsupportedOperationException("#isWrapperFor()");
     }
-
 }

--- a/src/main/java/com/jcabi/jdbc/Utc.java
+++ b/src/main/java/com/jcabi/jdbc/Utc.java
@@ -69,8 +69,9 @@ public final class Utc {
 
     /**
      * Public ctor.
-     * @param when The date to use.
+     * @param when The date to use
      */
+    // @checkstyle ConstructorsCodeFreeCheck (3 lines)
     public Utc(final Date when) {
         this.date = when.getTime();
     }
@@ -115,5 +116,4 @@ public final class Utc {
         }
         return when;
     }
-
 }

--- a/src/test/java/com/jcabi/jdbc/ColumnOutcomeTest.java
+++ b/src/test/java/com/jcabi/jdbc/ColumnOutcomeTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link ColumnOutcome}.
- *
  * @since 0.13
  */
 final class ColumnOutcomeTest {
@@ -42,5 +41,4 @@ final class ColumnOutcomeTest {
             "result collection should have size 2", names, Matchers.hasSize(2)
         );
     }
-
 }

--- a/src/test/java/com/jcabi/jdbc/H2Source.java
+++ b/src/test/java/com/jcabi/jdbc/H2Source.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 
 /**
  * H2 data source, for unit testing.
- *
  * @since 0.13
  */
 @ToString
@@ -89,5 +88,4 @@ final class H2Source implements DataSource {
     public boolean isWrapperFor(final Class<?> iface) {
         throw new UnsupportedOperationException("#isWrapperFor()");
     }
-
 }

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionITCase.java
@@ -6,8 +6,6 @@ package com.jcabi.jdbc;
 
 import com.jolbox.bonecp.BoneCPDataSource;
 import java.sql.CallableStatement;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Date;
 import java.util.UUID;
@@ -37,13 +35,11 @@ final class JdbcSessionITCase {
 
     /**
      * JdbcSession can do PostgreSQL manipulations.
-     *
      * @throws Exception If there is some problem inside
      */
     @Test
     void manipulatesPostgresql() throws Exception {
-        final DataSource source = this.source();
-        new JdbcSession(source)
+        new JdbcSession(this.source())
             .autocommit(false)
             .sql("CREATE TABLE IF NOT EXISTS foo (name VARCHAR(50))")
             .execute()
@@ -56,7 +52,6 @@ final class JdbcSessionITCase {
 
     /**
      * JdbcSession can manipulate UUID types.
-     *
      * @throws Exception If there is some problem inside
      */
     @Test
@@ -80,24 +75,21 @@ final class JdbcSessionITCase {
 
     /**
      * JdbcSession can change transaction isolation level.
-     *
      * @throws Exception If there is some problem inside
      */
     @Test
     void changesTransactionIsolationLevel() throws Exception {
-        final DataSource source = this.source();
-        new JdbcSession(source).sql("VACUUM").execute();
+        new JdbcSession(this.source()).sql("VACUUM").execute();
         MatcherAssert.assertThat("should complete", true, Matchers.is(true));
     }
 
     /**
      * JdbcSession can run a function (stored procedure) with
      * output parameters.
-     *
      * @throws Exception If something goes wrong
      */
     @Test
-    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+    @SuppressWarnings({"PMD.UnitTestContainsTooManyAsserts", "PMD.UnnecessaryLocalRule"})
     void callsFunctionWithOutParam() throws Exception {
         final DataSource source = this.source();
         new JdbcSession(source).autocommit(false).sql(
@@ -111,21 +103,14 @@ final class JdbcSessionITCase {
                 " FROM users; END; $$ LANGUAGE plpgsql;"
             )
         ).execute().commit();
+        final Preparation prep = stmt -> {
+            final CallableStatement cstmt = (CallableStatement) stmt;
+            cstmt.registerOutParameter(1, Types.VARCHAR);
+            cstmt.registerOutParameter(2, Types.DATE);
+        };
         final Object[] result = new JdbcSession(source)
             .sql("{call fetchUser(?, ?)}")
-            .prepare(
-                new Preparation() {
-                    @Override
-                    public void
-                        prepare(final PreparedStatement stmt)
-                        throws SQLException {
-                            final CallableStatement cstmt =
-                                (CallableStatement) stmt;
-                            cstmt.registerOutParameter(1, Types.VARCHAR);
-                            cstmt.registerOutParameter(2, Types.DATE);
-                    }
-                }
-             )
+            .prepare(prep)
             .call(new StoredProcedureOutcome<Object[]>(1, 2));
         MatcherAssert.assertThat("result array size should be 2", result.length, Matchers.is(2));
         MatcherAssert.assertThat(
@@ -143,11 +128,10 @@ final class JdbcSessionITCase {
     /**
      * JdbcSession can run a function (stored procedure) with
      * input and output parameters.
-     *
      * @throws Exception If something goes wrong
      */
     @Test
-    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
+    @SuppressWarnings({"PMD.UnitTestContainsTooManyAsserts", "PMD.UnnecessaryLocalRule"})
     void callsFunctionWithInOutParam() throws Exception {
         final DataSource source = this.source();
         new JdbcSession(source).autocommit(false).sql(
@@ -161,20 +145,12 @@ final class JdbcSessionITCase {
                 " END; $$ LANGUAGE plpgsql;"
             )
         ).execute().commit();
+        final Preparation prep = stmt -> ((CallableStatement) stmt)
+            .registerOutParameter(2, Types.VARCHAR);
         final Object[] result = new JdbcSession(source)
             .sql("{call fetchUserById(?, ?)}")
             .set(1)
-            .prepare(
-                new Preparation() {
-                    @Override
-                    public void
-                        prepare(final PreparedStatement stmt)
-                        throws SQLException {
-                            ((CallableStatement) stmt)
-                                .registerOutParameter(2, Types.VARCHAR);
-                    }
-                }
-             )
+            .prepare(prep)
             .call(new StoredProcedureOutcome<Object[]>(2));
         MatcherAssert.assertThat("result array length should be 1", result.length, Matchers.is(1));
         MatcherAssert.assertThat(
@@ -186,7 +162,6 @@ final class JdbcSessionITCase {
 
     /**
      * Get data source.
-     *
      * @return Source
      */
     private DataSource source() {
@@ -202,5 +177,4 @@ final class JdbcSessionITCase {
         src.setDisableConnectionTracking(true);
         return src;
     }
-
 }

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionMySqlITCase.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionMySqlITCase.java
@@ -20,7 +20,6 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * Integration case for {@link JdbcSession} on MySQL.
- *
  * @since 0.17.6
  */
 @Testcontainers(disabledWithoutDocker = true)
@@ -39,8 +38,7 @@ final class JdbcSessionMySqlITCase {
 
     @Test
     void worksWithExecute() throws Exception {
-        final DataSource source = this.source();
-        new JdbcSession(source)
+        new JdbcSession(this.source())
             .autocommit(false)
             .sql("CREATE TABLE foo (name VARCHAR(50))")
             .execute()
@@ -52,17 +50,17 @@ final class JdbcSessionMySqlITCase {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void worksLastInsertId() throws Exception {
+        final String create = StringUtils.join(
+            "CREATE TABLE IF NOT EXISTS foo (",
+            "id INT NOT NULL AUTO_INCREMENT, ",
+            "name VARCHAR(50), ",
+            "PRIMARY KEY (id)",
+            ")"
+        );
         new JdbcSession(this.source())
-            .sql(
-                StringUtils.join(
-                    "CREATE TABLE IF NOT EXISTS foo (",
-                    "id INT NOT NULL AUTO_INCREMENT, ",
-                    "name VARCHAR(50), ",
-                    "PRIMARY KEY (id)",
-                    ")"
-                )
-            )
+            .sql(create)
             .execute();
         MatcherAssert.assertThat(
             "result should be equal 1",
@@ -75,17 +73,17 @@ final class JdbcSessionMySqlITCase {
     }
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void worksLastInsertIdAndTransaction() throws Exception {
+        final String create = StringUtils.join(
+            "CREATE TABLE IF NOT EXISTS foo (",
+            "id INT NOT NULL AUTO_INCREMENT, ",
+            "name VARCHAR(50), ",
+            "PRIMARY KEY (id)",
+            ")"
+        );
         new JdbcSession(this.source())
-            .sql(
-                StringUtils.join(
-                    "CREATE TABLE IF NOT EXISTS foo (",
-                    "id INT NOT NULL AUTO_INCREMENT, ",
-                    "name VARCHAR(50), ",
-                    "PRIMARY KEY (id)",
-                    ")"
-                )
-            )
+            .sql(create)
             .execute();
         final JdbcSession session = new JdbcSession(this.source());
         MatcherAssert.assertThat(
@@ -105,29 +103,27 @@ final class JdbcSessionMySqlITCase {
     @Test
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void callsFunctionWithOutParam() throws Exception {
+        final String proc = StringUtils.join(
+            "CREATE PROCEDURE proc(OUT username text, OUT day date) ",
+            "BEGIN SELECT name, CURDATE() INTO username, day ",
+            "FROM users; ",
+            "SELECT username, day; ",
+            "END"
+        );
         new JdbcSession(this.source())
             .autocommit(false)
             .sql("CREATE TABLE IF NOT EXISTS users (name VARCHAR(50))")
             .execute()
             .sql("INSERT INTO users (name) VALUES (?)")
             .set("Jeff Charles").execute()
-            .sql(
-                StringUtils.join(
-                    "CREATE PROCEDURE proc(OUT username text, OUT day date) ",
-                    "BEGIN SELECT name, CURDATE() INTO username, day ",
-                    "FROM users; ",
-                    "SELECT username, day; ",
-                    "END"
-                )
-            ).execute().commit();
+            .sql(proc).execute().commit();
+        final Preparation prep = stmt -> {
+            ((CallableStatement) stmt).registerOutParameter(1, Types.VARCHAR);
+            ((CallableStatement) stmt).registerOutParameter(2, Types.DATE);
+        };
         final Object[] result = new JdbcSession(this.source())
             .sql("CALL proc(?, ?)")
-            .prepare(
-                stmt -> {
-                    ((CallableStatement) stmt).registerOutParameter(1, Types.VARCHAR);
-                    ((CallableStatement) stmt).registerOutParameter(2, Types.DATE);
-                }
-            )
+            .prepare(prep)
             .call(new StoredProcedureOutcome<>(1, 2));
         MatcherAssert.assertThat(
             "first item of result array should contains user name Jeff Charles and not null date",
@@ -141,7 +137,6 @@ final class JdbcSessionMySqlITCase {
 
     /**
      * Get data source.
-     *
      * @return Source
      */
     private DataSource source() {
@@ -151,5 +146,4 @@ final class JdbcSessionMySqlITCase {
         src.setPassword(this.container.getPassword());
         return src;
     }
-
 }

--- a/src/test/java/com/jcabi/jdbc/JdbcSessionTest.java
+++ b/src/test/java/com/jcabi/jdbc/JdbcSessionTest.java
@@ -5,10 +5,6 @@
 package com.jcabi.jdbc;
 
 import com.jcabi.aspects.Parallel;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import javax.sql.DataSource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -25,7 +21,7 @@ final class JdbcSessionTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    @SuppressWarnings({"PMD.UnnecessaryLocalRule", "PMD.CheckResultSet"})
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void sendsSqlManipulationsToJdbcDriver() throws Exception {
         final DataSource source = new H2Source("tiu78");
         new JdbcSession(source)
@@ -36,19 +32,13 @@ final class JdbcSessionTest {
             .set("Jeff Lebowski")
             .execute()
             .commit();
+        final Outcome<String> outcome = (rset, stmt) -> {
+            rset.next();
+            return rset.getString(1);
+        };
         final String name = new JdbcSession(source)
             .sql("SELECT name FROM foo WHERE name = 'Jeff Lebowski'")
-            .select(
-                new Outcome<String>() {
-                    @Override
-                    public String handle(final ResultSet rset,
-                        final Statement stmt)
-                        throws SQLException {
-                        rset.next();
-                        return rset.getString(1);
-                    }
-                }
-            );
+            .select(outcome);
         MatcherAssert.assertThat("result starts with Jeff", name, Matchers.startsWith("Jeff"));
     }
 
@@ -76,36 +66,23 @@ final class JdbcSessionTest {
      * @throws Exception If there is some problem inside
      */
     @Test
-    @SuppressWarnings({"PMD.UnnecessaryLocalRule", "PMD.CheckResultSet"})
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void automaticallyCommitsByDefault() throws Exception {
         final DataSource source = new H2Source("tt8u");
+        final Preparation prep = stmt -> stmt.setString(1, "Walter");
         new JdbcSession(source)
             .sql("CREATE TABLE foo16 (name VARCHAR(50))")
             .execute()
             .sql("INSERT INTO foo16 (name) VALUES (?)")
-            .prepare(
-                new Preparation() {
-                    @Override
-                    public void prepare(final PreparedStatement stmt)
-                        throws SQLException {
-                        stmt.setString(1, "Walter");
-                    }
-                }
-            )
+            .prepare(prep)
             .execute();
+        final Outcome<String> outcome = (rset, stmt) -> {
+            rset.next();
+            return rset.getString(1);
+        };
         final String name = new JdbcSession(source)
             .sql("SELECT name FROM foo16 WHERE name = 'Walter'")
-            .select(
-                new Outcome<String>() {
-                    @Override
-                    public String handle(final ResultSet rset,
-                        final Statement stmt)
-                        throws SQLException {
-                        rset.next();
-                        return rset.getString(1);
-                    }
-                }
-            );
+            .select(outcome);
         MatcherAssert.assertThat("result starts with Wa", name, Matchers.startsWith("Wa"));
     }
 
@@ -181,5 +158,4 @@ final class JdbcSessionTest {
             .sql(String.format("INSERT INTO %s VALUES ('hey')", table))
             .execute();
     }
-
 }

--- a/src/test/java/com/jcabi/jdbc/ListOutcomeTest.java
+++ b/src/test/java/com/jcabi/jdbc/ListOutcomeTest.java
@@ -34,16 +34,14 @@ final class ListOutcomeTest {
             .set("Walter Sobchak")
             .execute()
             .commit();
+        final ListOutcome<String> outcome = new ListOutcome<>(
+            rset -> rset.getString(1)
+        );
         final Collection<String> names = new JdbcSession(source)
             .sql("SELECT name FROM foo")
-            .select(
-                new ListOutcome<>(
-                    rset -> rset.getString(1)
-                )
-            );
+            .select(outcome);
         MatcherAssert.assertThat(
             "names collection size should be 2", names, Matchers.hasSize(2)
         );
     }
-
 }

--- a/src/test/java/com/jcabi/jdbc/OutcomeTest.java
+++ b/src/test/java/com/jcabi/jdbc/OutcomeTest.java
@@ -31,5 +31,4 @@ final class OutcomeTest {
             .update(Outcome.LAST_INSERT_ID);
         MatcherAssert.assertThat("last insert id is equal 1", num, Matchers.equalTo(1L));
     }
-
 }

--- a/src/test/java/com/jcabi/jdbc/SingleOutcomeTest.java
+++ b/src/test/java/com/jcabi/jdbc/SingleOutcomeTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link SingleOutcome}.
- *
  * @since 0.1
  */
 final class SingleOutcomeTest {
@@ -106,8 +105,7 @@ final class SingleOutcomeTest {
 
     /**
      * Create datasource.
-     *
-     * @return Source.
+     * @return Source
      */
     private DataSource datasource() {
         return new H2Source("ytt68");

--- a/src/test/java/com/jcabi/jdbc/UrlSourceTest.java
+++ b/src/test/java/com/jcabi/jdbc/UrlSourceTest.java
@@ -10,16 +10,15 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link UrlSource}.
- *
  * @since 0.19.0
  */
 final class UrlSourceTest {
 
     @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void sendsSqlManipulationsToJdbcDriver() throws Exception {
-        new JdbcSession(
-            new UrlSource("jdbc:h2:mem:foo;DB_CLOSE_DELAY=-1")
-        )
+        final UrlSource source = new UrlSource("jdbc:h2:mem:foo;DB_CLOSE_DELAY=-1");
+        new JdbcSession(source)
             .autocommit(false)
             .sql("CREATE TABLE foo (name VARCHAR(50))")
             .execute()

--- a/src/test/java/com/jcabi/jdbc/UtcTest.java
+++ b/src/test/java/com/jcabi/jdbc/UtcTest.java
@@ -40,11 +40,13 @@ final class UtcTest {
     /**
      * Format to use in tests.
      */
+    // @checkstyle ProhibitFieldsInTestClassesCheck (3 lines)
     private transient DateFormat fmt;
 
     /**
      * Data source.
      */
+    // @checkstyle ProhibitFieldsInTestClassesCheck (3 lines)
     private transient DataSource source;
 
     /**
@@ -57,7 +59,7 @@ final class UtcTest {
             String.format("xpo%d", UtcTest.RND.nextInt())
         );
         new JdbcSession(this.source)
-            .sql("CREATE TABLE foo (date DATETIME)")
+            .sql("CREATE TABLE foo (date TIMESTAMP)")
             .execute();
         this.fmt = new SimpleDateFormat(
             "yyyy-MM-dd HH:mm:ss.SSS", Locale.ENGLISH
@@ -75,15 +77,20 @@ final class UtcTest {
         );
         final Date date = this.fmt.parse("2008-05-24 05:06:07.000");
         final String saved;
-        try (Connection conn = this.source.getConnection();
+        try (
+            Connection conn = this.source.getConnection();
             PreparedStatement ustmt = conn.prepareStatement(
                 "INSERT INTO foo (date) VALUES (?)"
-            )) {
+            )
+        ) {
             new Utc(date).setTimestamp(ustmt, 1);
             ustmt.executeUpdate();
-            try (PreparedStatement rstmt = conn.prepareStatement(
-                "SELECT date FROM foo"
-            ); ResultSet rset = rstmt.executeQuery()) {
+            try (
+                PreparedStatement rstmt = conn.prepareStatement(
+                    "SELECT date FROM foo"
+                );
+                ResultSet rset = rstmt.executeQuery()
+            ) {
                 if (!rset.next()) {
                     throw new IllegalArgumentException();
                 }
@@ -104,15 +111,20 @@ final class UtcTest {
     @Test
     void loadsDateWithUtcTimezone() throws Exception {
         final Date loaded;
-        try (Connection conn = this.source.getConnection();
+        try (
+            Connection conn = this.source.getConnection();
             PreparedStatement ustmt = conn.prepareStatement(
                 "INSERT INTO foo (date) VALUES (?) "
-             )) {
+            )
+        ) {
             ustmt.setString(1, "2005-02-02 10:07:08.000");
             ustmt.executeUpdate();
-            try (PreparedStatement rstmt = conn.prepareStatement(
-                "SELECT date FROM foo "
-            ); ResultSet rset = rstmt.executeQuery()) {
+            try (
+                PreparedStatement rstmt = conn.prepareStatement(
+                    "SELECT date FROM foo "
+                );
+                ResultSet rset = rstmt.executeQuery()
+            ) {
                 if (!rset.next()) {
                     throw new IllegalArgumentException();
                 }
@@ -141,10 +153,13 @@ final class UtcTest {
             .set(new Utc(date))
             .insert(Outcome.VOID);
         final String saved;
-        try (Connection conn = this.source.getConnection();
+        try (
+            Connection conn = this.source.getConnection();
             PreparedStatement stmt = conn.prepareStatement(
                 "SELECT date FROM foo  "
-            ); ResultSet rset = stmt.executeQuery()) {
+            );
+            ResultSet rset = stmt.executeQuery()
+        ) {
             if (!rset.next()) {
                 throw new IllegalStateException();
             }
@@ -158,5 +173,4 @@ final class UtcTest {
             Matchers.equalTo(date.toString())
         );
     }
-
 }

--- a/src/test/java/com/jcabi/jdbc/package-info.java
+++ b/src/test/java/com/jcabi/jdbc/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * JDBC wrapper, tests.
- *
  * @since 0.1.8
  */
 package com.jcabi.jdbc;


### PR DESCRIPTION
@yegor256 — this PR brings every direct dependency, plugin, and the qulice linter up to the latest stable versions, then resolves every lint issue (new and pre-existing) so the build is green again on all three OSes.

## Dependency bumps

| Artifact | From | To |
|---|---|---|
| `com.h2database:h2` (test) | 2.3.232 | 2.4.240 |
| `org.postgresql:postgresql` (test) | 42.7.10 | 42.7.11 |
| `com.mysql:mysql-connector-j` (test) | 9.6.0 | 9.7.0 |
| `org.testcontainers:testcontainers` (test) | 2.0.3 | 2.0.5 |
| `org.apache.logging.log4j:log4j-core` (test) | 2.25.3 | 2.25.4 |
| `org.aspectj:aspectjrt` | 1.9.25 | 1.9.25.1 |
| `org.projectlombok:lombok` | 1.18.44 | 1.18.46 |
| `com.qulice:qulice-maven-plugin` | 0.25.1 | 0.27.5 |

## CI matrix change

The previous mvn matrix included Java 11, but qulice (both 0.25.1 and 0.27.5) is compiled for Java 17+, so every recent master build had been failing the `mvn (*, 11)` jobs with `UnsupportedClassVersionError`. The matrix is now `java: [21]`, matching `jcabi-urn`, `jcabi-velocity`, and the rest of the org.

## Code-level adjustments required by these bumps

- **H2 2.4.x removed `DATETIME`** ([h2database/h2database#4285](https://github.com/h2database/h2database/issues/4285)). `UtcTest` now creates its `foo` table with `TIMESTAMP`, which has the same semantics it relied on.
- **qulice 0.27.5 enables several new checkstyle/PMD rules.** The diff resolves every new violation across `main` and `test` rather than suppressing the rule globally:
  - `JavadocEmptyLineBeforeTagCheck` – removed empty `*` lines before single-paragraph javadoc `@`-tags; added them back where the description really has multiple paragraphs (`<p>`, `<ul>`, `<pre>`).
  - `RegexpMultilineCheck` ("empty line before closing brace") – stripped those blank lines.
  - `JavadocTagsDotCheck` – trimmed trailing dots from `@param`/`@return`/`@throws` lines.
  - `EmptyLineBeforeFirstMemberCheck` – inserted the required blank line after class/interface/enum opening braces.
  - `ConstructorsOrderCheck` – moved the primary constructor last in `ColumnOutcome`, `SingleOutcome`, and `DefaultMappings`.
  - `ConstructorsCodeFreeCheck` – extracted the `Stream` builder out of `DefaultMappings(int)` into a private static `defaults(int)` factory; collapsed `Utc(Date)` to assign directly. The remaining unavoidable cases (constructor delegations doing a single dispatch such as `mps.forType(type)`) carry the standard `// @checkstyle ConstructorsCodeFreeCheck` nearby-comment suppression.
  - `MethodDeclarationLengthCheck` – joined `insert`/`update`/`call`/`select` signatures onto one line.
  - `RegexpSinglelineCheck` ("fluent call opening a multi-line block must be attached to the previous line") – hoisted multi-line anonymous classes / lambdas out of fluent chains into local variables in `JdbcSessionTest`, `JdbcSessionITCase`, `JdbcSessionMySqlITCase`, and `ListOutcomeTest`. The anonymous `Outcome` and `Preparation` classes were converted to lambdas in the process.
  - `ProhibitFieldsInTestClassesCheck` – the two `@BeforeEach`-managed fields in `UtcTest` are kept (the `@BeforeEach` setup pattern is the right shape for them) and tagged with the standard `// @checkstyle ProhibitFieldsInTestClassesCheck` suppression.
  - `BracketsStructureCheck` – reformatted `try`-with-resources blocks in `UtcTest` so each resource is on its own line and the closing `)` sits on its own line.
  - `CascadeIndentationCheck` – simplified `UrlSourceTest` by extracting the `UrlSource` to a local.
  - PMD `UnnecessaryImport` – removed `java.sql.PreparedStatement`, `java.sql.ResultSet`, `java.sql.SQLException`, `java.sql.Statement`, and `java.util.Collections` imports that became unused after the lambda refactors.
  - PMD `UnnecessaryWarningSuppression` – dropped `PMD.CheckResultSet` suppressions the new ruleset no longer needs.
  - PMD `UnnecessaryLocalRule` – the locals introduced for the fluent-call rule above are required for checkstyle compliance, so the affected test methods carry a focused `@SuppressWarnings("PMD.UnnecessaryLocalRule")`.

## CI status

All 11 checks are green on the current head (`d61cdf5`):

- mvn (ubuntu-24.04, 21), mvn (macos-15, 21), mvn (windows-2022, 21)
- actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint

Ready for review/merge.