### PR TITLE
Drop hard-coded JUnit versions, defer to parent BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,31 +156,26 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-engine</artifactId>
-      <version>1.14.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-commons</artifactId>
-      <version>1.14.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.14.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.14.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>5.14.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
@yegor256

This PR consolidates the JUnit dependency graph in `jcabi-jdbc`.

The parent `com.jcabi:jcabi-parent` 0.73.1 imports
`org.junit:junit-bom:6.0.3` via `dependencyManagement`. As a result,
`junit-jupiter-params` (which has no version in this POM) was already
resolving to 6.0.3, while the explicitly pinned ones in the POM stayed
on the older 5.14.x / 1.14.x lines:

| Artifact | Before | After |
|---|---|---|
| `junit-jupiter-api` | 5.14.0 | 6.0.3 (from parent BOM) |
| `junit-jupiter-engine` | 5.14.0 | 6.0.3 (from parent BOM) |
| `junit-vintage-engine` | 5.14.0 | 6.0.3 (from parent BOM) |
| `junit-platform-engine` | 1.14.0 | 6.0.3 (from parent BOM) |
| `junit-platform-commons` | 1.14.0 | 6.0.3 (from parent BOM) |

Removing the explicit versions lets the parent BOM drive the whole
JUnit graph, matching `junit-jupiter-params` and removing the version
mismatch.

`mvn dependency:tree -Dincludes="org.junit.*"` after the change:

```
+- org.junit.platform:junit-platform-engine:jar:6.0.3:test
+- org.junit.platform:junit-platform-commons:jar:6.0.3:test
+- org.junit.jupiter:junit-jupiter-api:jar:6.0.3:test
+- org.junit.jupiter:junit-jupiter-engine:jar:6.0.3:test
+- org.junit.vintage:junit-vintage-engine:jar:6.0.3:test
\- org.junit.jupiter:junit-jupiter-params:jar:6.0.3:test
```

### Verification

Local: `mvn --errors --batch-mode clean install -Pqulice` is green
(20 unit tests pass; the 9 testcontainers integration tests skip
without Docker, as they did before).

CI: all 11 checks on this PR are green
(`mvn` on ubuntu-24.04 / windows-2022 / macos-15 with Java 21,
`actionlint`, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `typos`,
`xcop`, `yamllint`).

Ready for your review.
